### PR TITLE
Update validator lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ documentation = "https://docs.rs/actix-web-validator/"
 [dependencies]
 actix-web = { version = "3", default-features = false }
 derive_more = "0.99"
-validator = "0.11"
-validator_derive = "0.11"
+validator = { version = "0.12", features = ["derive"] }
 serde = "1"
 serde_urlencoded = "0.7"
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ actix-web-validator = "2.0.1"
 use actix_web::{web, App};
 use serde_derive::Deserialize;
 use actix_web_validator::Query;
-use validator_derive::Validate;
+use validator::Validate;
 
 #[derive(Debug, Deserialize)]
 pub enum ResponseType {

--- a/src/json.rs
+++ b/src/json.rs
@@ -30,7 +30,6 @@ use crate::error::Error;
 /// use actix_web_validator::Json;
 /// use serde_derive::Deserialize;
 /// use validator::Validate;
-/// use validator_derive::Validate;
 ///
 /// #[derive(Deserialize, Validate)]
 /// struct Info {
@@ -53,7 +52,10 @@ use crate::error::Error;
 #[derive(Debug)]
 pub struct Json<T>(pub T);
 
-#[deprecated(note = "Please, use actix_web_validator::Json instead.", since = "2.0.0")]
+#[deprecated(
+    note = "Please, use actix_web_validator::Json instead.",
+    since = "2.0.0"
+)]
 pub type ValidatedJson<T> = Json<T>;
 
 impl<T> Json<T> {
@@ -96,7 +98,6 @@ impl<T> Deref for Json<T> {
 /// use actix_web_validator::Json;
 /// use serde_derive::Deserialize;
 /// use validator::Validate;
-/// use validator_derive::Validate;
 ///
 /// #[derive(Deserialize, Validate)]
 /// struct Info {
@@ -135,10 +136,7 @@ where
         JsonBody::new(req, payload, ctype)
             .limit(limit)
             .map(|res: Result<T, _>| match res {
-                Ok(data) => data
-                    .validate()
-                    .map(|_| Json(data))
-                    .map_err(Error::from),
+                Ok(data) => data.validate().map(|_| Json(data)).map_err(Error::from),
                 Err(e) => Err(Error::from(e)),
             })
             .map(move |res| match res {
@@ -167,7 +165,6 @@ where
 /// use serde_derive::Deserialize;
 /// use actix_web_validator::{Json, JsonConfig};
 /// use validator::Validate;
-/// use validator_derive::Validate;
 ///
 /// #[derive(Deserialize, Validate)]
 /// struct Info {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 //! use serde_derive::Deserialize;
 //! use actix_web_validator::ValidatedQuery;
 //! use validator::Validate;
-//! use validator_derive::Validate;
 //!
 //! #[derive(Debug, Deserialize)]
 //! pub enum ResponseType {

--- a/src/path.rs
+++ b/src/path.rs
@@ -24,7 +24,6 @@ use crate::error::{DeserializeErrors, Error};
 /// use serde_derive::Deserialize;
 /// use actix_web_validator::Path;
 /// use validator::Validate;
-/// use validator_derive::Validate;
 ///
 /// #[derive(Deserialize, Validate)]
 /// struct Info {
@@ -49,7 +48,10 @@ pub struct Path<T> {
     inner: T,
 }
 
-#[deprecated(note = "Please, use actix_web_validator::Path instead.", since = "2.0.0")]
+#[deprecated(
+    note = "Please, use actix_web_validator::Path instead.",
+    since = "2.0.0"
+)]
 pub type ValidatedPath<T> = Path<T>;
 
 impl<T> Path<T> {
@@ -97,7 +99,6 @@ impl<T: fmt::Display> fmt::Display for Path<T> {
 /// use serde_derive::Deserialize;
 /// use actix_web_validator::Path;
 /// use validator::Validate;
-/// use validator_derive::Validate;
 ///
 /// #[derive(Deserialize, Validate)]
 /// struct Info {
@@ -163,7 +164,6 @@ where
 /// use actix_web_validator::{PathConfig, Path};
 /// use actix_web::{error, web, App, FromRequest, HttpResponse};
 /// use validator::Validate;
-/// use validator_derive::Validate;
 /// use serde_derive::Deserialize;
 ///
 /// #[derive(Deserialize, Debug)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -17,7 +17,7 @@ use validator::Validate;
 /// use actix_web::{error, web, App, FromRequest, HttpResponse};
 /// use serde_derive::Deserialize;
 /// use actix_web_validator::{Query, QueryConfig};
-/// use validator_derive::Validate;
+/// use validator::Validate;
 ///
 /// #[derive(Deserialize, Validate)]
 /// struct Info {
@@ -78,7 +78,7 @@ impl Default for QueryConfig {
 /// use actix_web::{web, App};
 /// use serde_derive::Deserialize;
 /// use actix_web_validator::Query;
-/// use validator_derive::Validate;
+/// use validator::Validate;
 ///
 /// #[derive(Debug, Deserialize)]
 /// pub enum ResponseType {
@@ -109,7 +109,10 @@ impl Default for QueryConfig {
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub struct Query<T>(pub T);
 
-#[deprecated(note = "Please, use actix_web_validator::Query instead.", since = "2.0.0")]
+#[deprecated(
+    note = "Please, use actix_web_validator::Query instead.",
+    since = "2.0.0"
+)]
 pub type ValidatedQuery<T> = Query<T>;
 
 impl<T> AsRef<T> for Query<T> {
@@ -163,7 +166,6 @@ where
 /// use serde_derive::Deserialize;
 /// use actix_web_validator::Query;
 /// use validator::Validate;
-/// use validator_derive::Validate;
 ///
 /// #[derive(Debug, Deserialize)]
 /// pub enum ResponseType {

--- a/tests/test_json_validation.rs
+++ b/tests/test_json_validation.rs
@@ -1,9 +1,9 @@
 use actix_web::{
     error, http::StatusCode, test, test::call_service, web, App, FromRequest, HttpResponse,
 };
-use actix_web_validator::{JsonConfig, Json};
+use actix_web_validator::{Json, JsonConfig};
 use serde_derive::{Deserialize, Serialize};
-use validator_derive::Validate;
+use validator::Validate;
 
 #[derive(Debug, PartialEq, Validate, Serialize, Deserialize)]
 struct JsonPayload {

--- a/tests/test_path_validation.rs
+++ b/tests/test_path_validation.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use actix_web::{error, http::StatusCode, test, test::call_service, web, App, HttpResponse};
 use actix_web_validator::Path;
 use serde_derive::Deserialize;
-use validator_derive::Validate;
+use validator::Validate;
 
 #[derive(Debug, Validate, Deserialize, PartialEq)]
 struct PathParams {

--- a/tests/test_query_validation.rs
+++ b/tests/test_query_validation.rs
@@ -1,7 +1,7 @@
 use actix_web::{error, http::StatusCode, test, test::call_service, web, App, HttpResponse};
 use actix_web_validator::Query;
 use serde_derive::Deserialize;
-use validator_derive::Validate;
+use validator::Validate;
 
 #[derive(Debug, Validate, Deserialize, PartialEq)]
 struct QueryParams {


### PR DESCRIPTION
I was using this lib and noticed that validator released a new version and this lib was not up-to-date. This looked straightforward enough that I took the time to do it. Please see if this is something that you need. Would appreciate it if we can get this merged.

Disclaimer: I am very new to rust. So if there is some horrible error that I have made, please take some time out to guide me. I am using rust-fmt for formatting and it looks like it modified some lines. If this is not acceptable then I will change it.