### PR TITLE
feat: validate form

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/actix-web-validator/"
 
 [dependencies]
 actix-web = { version = "3", default-features = false }
+actix-http = { version = "2" }
 derive_more = "0.99"
 validator = { version = "0.12" }
 serde = "1"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ serde = { version = "1", features = ["derive"] }
 * `actix_web::web::Json`
 * `actix_web::web::Query`
 * `actix_web::web::Path`
+* `actix_web::web::Form`
 * `serde_qs::actix::QsQuery` 
 
 ### Supported `actix_web` versions:

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,8 @@ pub enum Error {
     Deserialize(DeserializeErrors),
     #[display(fmt = "Payload error: {}", _0)]
     JsonPayloadError(actix_web::error::JsonPayloadError),
+    #[display(fmt = "Url encoded error: {}", _0)]
+    UrlEncodedError(actix_web::error::UrlencodedError),
     #[display(fmt = "Query error: {}", _0)]
     QsError(serde_qs::Error),
 }
@@ -52,6 +54,12 @@ impl From<actix_web::error::JsonPayloadError> for Error {
 impl From<validator::ValidationErrors> for Error {
     fn from(error: validator::ValidationErrors) -> Self {
         Error::Validate(error)
+    }
+}
+
+impl From<actix_web::error::UrlencodedError> for Error {
+    fn from(error: actix_web::error::UrlencodedError) -> Self {
+        Error::UrlEncodedError(error)
     }
 }
 

--- a/src/form.rs
+++ b/src/form.rs
@@ -1,0 +1,203 @@
+use actix_http::Payload;
+use actix_web::{dev::UrlEncoded, FromRequest, HttpRequest};
+use futures::future::LocalBoxFuture;
+use futures::FutureExt;
+use serde::de::DeserializeOwned;
+use std::{ops::Deref, rc::Rc};
+use validator::Validate;
+
+use crate::Error;
+
+/// Form can be used for extracting typed information and validation
+/// from request's form data.
+///
+/// To extract and typed information from request's form data, the type `T` must
+/// implement the `Deserialize` trait from *serde*
+/// and `Validate` trait from *validator* crate.
+///
+/// [**FormConfig**](struct.FormConfig.html) allows to configure extraction
+/// process.
+///
+/// ## Example
+///
+/// ```rust
+/// use actix_web::{web, App};
+/// use actix_web_validator::Form;
+/// use serde::Deserialize;
+/// use validator::Validate;
+///
+/// #[derive(Deserialize, Validate)]
+/// struct Info {
+///     #[validate(length(min = 3))]
+///     username: String,
+/// }
+///
+/// /// deserialize `Info` from request's form data
+/// async fn index(info: Form<Info>) -> String {
+///     format!("Welcome {}!", info.username)
+/// }
+///
+/// fn main() {
+///     let app = App::new().service(
+///        web::resource("/index.html").route(
+///            web::post().to(index))
+///     );
+/// }
+/// ```
+#[derive(Debug)]
+pub struct Form<T>(pub T);
+
+impl<T> Form<T> {
+    /// Deconstruct to an inner value
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> AsRef<T> for Form<T> {
+    fn as_ref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> Deref for Form<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+/// Form data helper (`application/x-www-form-urlencoded`). Allow to extract typed information from request's
+/// payload and validate it.
+///
+/// To extract typed information from request's body, the type `T` must
+/// implement the `Deserialize` trait from *serde*.
+///
+/// To validate payload, the type `T` must implement the `Validate` trait
+/// from *validator* crate.
+///
+/// [**FormConfig**](struct.FormConfig.html) allows to configure extraction
+/// process.
+///
+/// ## Example
+///
+/// ```rust
+/// use actix_web::{web, App};
+/// use actix_web_validator::Form;
+/// use serde::Deserialize;
+/// use validator::Validate;
+///
+/// #[derive(Deserialize, Validate)]
+/// struct Info {
+///     #[validate(length(min = 3))]
+///     username: String,
+/// }
+///
+/// /// deserialize `Info` from request's form data
+/// async fn index(info: Form<Info>) -> String {
+///     format!("Welcome {}!", info.username)
+/// }
+/// ```
+impl<T> FromRequest for Form<T>
+where
+    T: DeserializeOwned + Validate + 'static,
+{
+    type Error = actix_http::Error;
+    type Future = LocalBoxFuture<'static, Result<Self, Self::Error>>;
+    type Config = FormConfig;
+
+    #[inline]
+    fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
+        let req2 = req.clone();
+        let (limit, error_handler) = req
+            .app_data::<Self::Config>()
+            .map(|c| (c.limit, c.ehandler.clone()))
+            .unwrap_or((16_384, None));
+
+        UrlEncoded::new(req, payload)
+            .limit(limit)
+            .map(|res: Result<T, _>| match res {
+                Ok(data) => data.validate().map(|_| Form(data)).map_err(Error::from),
+                Err(e) => Err(Error::from(e)),
+            })
+            .map(move |res| match res {
+                Err(e) => {
+                    if let Some(err) = error_handler {
+                        Err((*err)(e, &req2))
+                    } else {
+                        Err(e.into())
+                    }
+                }
+                Ok(item) => Ok(item),
+            })
+            .boxed_local()
+    }
+}
+
+/// Form extractor configuration
+///
+/// ```rust
+/// use actix_web::{error, web, App, FromRequest, HttpResponse};
+/// use serde::Deserialize;
+/// use actix_web_validator::{Form, FormConfig};
+/// use validator::Validate;
+///
+/// #[derive(Deserialize, Validate)]
+/// struct Info {
+///     #[validate(length(min = 3))]
+///     username: String,
+/// }
+///
+/// /// deserialize `Info` from request's form data, max payload size is 4kb
+/// async fn index(info: Form<Info>) -> String {
+///     format!("Welcome {}!", info.username)
+/// }
+///
+/// fn main() {
+///     let app = App::new().service(
+///         web::resource("/index.html")
+///             .app_data(
+///                 // change form data extractor configuration
+///                 Form::<Info>::configure(|cfg| {
+///                     cfg.limit(4096)
+///                        .error_handler(|err, req| {  // <- create custom error response
+///                           error::InternalError::from_response(
+///                               err, HttpResponse::Conflict().finish()).into()
+///                        })
+///             }))
+///             .route(web::post().to(index))
+///     );
+/// }
+/// ```
+#[derive(Clone)]
+pub struct FormConfig {
+    limit: usize,
+    ehandler: Option<Rc<dyn Fn(Error, &HttpRequest) -> actix_http::Error>>,
+}
+
+impl FormConfig {
+    /// Change max size of payload. By default max size is 16Kb
+    pub fn limit(mut self, limit: usize) -> Self {
+        self.limit = limit;
+        self
+    }
+
+    /// Set custom error handler
+    pub fn error_handler<F>(mut self, f: F) -> Self
+    where
+        F: Fn(Error, &HttpRequest) -> actix_http::Error + 'static,
+    {
+        self.ehandler = Some(Rc::new(f));
+        self
+    }
+}
+
+impl Default for FormConfig {
+    fn default() -> Self {
+        Self {
+            limit: 16_384,
+            ehandler: None,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,11 +39,13 @@
 //! }
 //! ```
 pub mod error;
+mod form;
 mod json;
 mod path;
 mod qsquery;
 mod query;
 pub use error::Error;
+pub use form::*;
 pub use json::*;
 pub use path::*;
 pub use qsquery::*;

--- a/tests/test_form_validation.rs
+++ b/tests/test_form_validation.rs
@@ -1,0 +1,149 @@
+use actix_web::{
+    error,
+    http::StatusCode,
+    test,
+    test::call_service,
+    web::{self},
+    App, FromRequest, HttpResponse,
+};
+use actix_web_validator::{Form, FormConfig};
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+#[derive(Debug, PartialEq, Validate, Serialize, Deserialize)]
+struct FormData {
+    #[validate(url)]
+    page_url: String,
+    #[validate(range(min = 18, max = 28))]
+    age: u8,
+}
+
+async fn test_handler(query: Form<FormData>) -> HttpResponse {
+    dbg!(&query.into_inner());
+    HttpResponse::Ok().finish()
+}
+
+#[actix_rt::test]
+async fn test_form_validation() {
+    let mut app = test::init_service(
+        App::new().service(web::resource("/test").route(web::post().to(test_handler))),
+    )
+    .await;
+
+    // Test 200 status
+    let req = test::TestRequest::post()
+        .uri("/test")
+        .set_form(&FormData {
+            page_url: "https://my_page.com".to_owned(),
+            age: 24,
+        })
+        .to_request();
+    let resp = call_service(&mut app, req).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Test 400 status
+    let req = test::TestRequest::post()
+        .uri("/test")
+        .set_form(&FormData {
+            page_url: "invalid_url".to_owned(),
+            age: 24,
+        })
+        .to_request();
+    let resp = call_service(&mut app, req).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[actix_rt::test]
+async fn test_custom_form_validation_error() {
+    let mut app = test::init_service(
+        App::new().service(
+            web::resource("/test")
+                .app_data(Form::<FormData>::configure(|cfg| {
+                    cfg.error_handler(|err, _req| {
+                        error::InternalError::from_response(err, HttpResponse::Conflict().finish())
+                            .into()
+                    })
+                }))
+                .route(web::post().to(test_handler)),
+        ),
+    )
+    .await;
+
+    let req = test::TestRequest::post()
+        .uri("/test")
+        .set_form(&FormData {
+            page_url: "invalid".to_owned(),
+            age: 24,
+        })
+        .to_request();
+    let resp = call_service(&mut app, req).await;
+    dbg!(&resp);
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+#[actix_rt::test]
+async fn test_validated_form_asref_deref() {
+    let mut app = test::init_service(App::new().service(web::resource("/test").to(
+        |payload: Form<FormData>| {
+            assert_eq!(payload.age, 24);
+            let reference = FormData {
+                page_url: "https://my_page.com".to_owned(),
+                age: 24,
+            };
+            assert_eq!(payload.as_ref(), &reference);
+            HttpResponse::Ok().finish()
+        },
+    )))
+    .await;
+
+    let req = test::TestRequest::post()
+        .uri("/test")
+        .set_form(&FormData {
+            page_url: "https://my_page.com".to_owned(),
+            age: 24,
+        })
+        .to_request();
+    call_service(&mut app, req).await;
+}
+
+#[actix_rt::test]
+async fn test_validated_form_into_inner() {
+    let mut app = test::init_service(App::new().service(web::resource("/test").to(
+        |payload: Form<FormData>| {
+            let payload = payload.into_inner();
+            assert_eq!(payload.age, 24);
+            assert_eq!(payload.page_url, "https://my_page.com");
+            HttpResponse::Ok().finish()
+        },
+    )))
+    .await;
+
+    let req = test::TestRequest::post()
+        .uri("/test")
+        .set_form(&FormData {
+            page_url: "https://my_page.com".to_owned(),
+            age: 24,
+        })
+        .to_request();
+    call_service(&mut app, req).await;
+}
+
+#[actix_rt::test]
+async fn test_validated_form_limit() {
+    let mut app = test::init_service(
+        App::new()
+            .app_data(FormConfig::default().limit(1))
+            .service(web::resource("/test").route(web::post().to(test_handler))),
+    )
+    .await;
+
+    let req = test::TestRequest::post()
+        .uri("/test")
+        .set_form(&FormData {
+            page_url: "https://my_page.com".to_owned(),
+            age: 24,
+        })
+        .to_request();
+    let resp = call_service(&mut app, req).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}


### PR DESCRIPTION
Hi everybody, this PR :
- implements `Form` and `FormConfig`
- add tests
- add documentation

It follows the same implementation pattern as per the other structs (`Json`, `JsonConfig` and so on).
:)