### PR TITLE
Potential fix for nested struct message error format

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -103,6 +103,7 @@ fn format_errors(errors: &validator::ValidationErrors, indent: Option<usize>) ->
         .join("\n")
 }
 
+#[cfg(test)]
 mod test {
     use serde::{Deserialize, Serialize};
     use validator::Validate;

--- a/src/error.rs
+++ b/src/error.rs
@@ -134,6 +134,11 @@ mod test {
         .expect("invalid json");
         let validation = params.validate();
         let msg = crate::error::format_errors(&validation.unwrap_err(), None);
-        assert_eq!(msg, "\tpage_params:\n\t\tpage_size: range\n\t\tpage: range\n\tredirect_results: url");
+        assert!(msg.contains("page_params"));
+        assert!(msg.contains("page_size"));
+        assert!(msg.contains("range"));
+        assert!(msg.contains("page"));
+        assert!(msg.contains("redirect_results"));
+        assert!(msg.contains("url"));
     }
 }


### PR DESCRIPTION
Basically, current error format takes into account only ValidationErrorsKind variant [Field](https://docs.rs/validator/latest/validator/enum.ValidationErrorsKind.html#variant.Field) variant.
But nested struct with `#[validate]` annotation is represented as a ValidationErrorsKind variant [Struct](https://docs.rs/validator/latest/validator/enum.ValidationErrorsKind.html#variant.Struct).
This pull request offers a way to represent them, by recursively calling format method.
Given any representation is quite subjective, it's entirely a suggestion.

TODO:
- it doesn't account for ValidationErrorsKind variant [List](https://docs.rs/validator/latest/validator/enum.ValidationErrorsKind.html#variant.List) yet
- it suggests that indent could be constrained (past a few indents, error message probably lose in readability)