### PR TITLE
Updated validator to `0.18`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/actix-web-validator/"
 [dependencies]
 actix-web = { version = "4", default-features = false }
 actix-http = { version = "3" }
-validator = { version = "0.16" }
+validator = { version = "0.18" }
 serde = "1"
 serde_urlencoded = "0.7"
 serde_json = "1"
@@ -29,6 +29,6 @@ thiserror = "1.0"
 
 [dev-dependencies]
 actix-web = { version = "4", default-features = false, features = ["macros"] }
-validator = { version = "0.16", features = ["derive"]}
+validator = { version = "0.18", features = ["derive"]}
 serde = { version = "1", features = ["derive"] }
 actix-service = "2"

--- a/tests/test_error_transformation.rs
+++ b/tests/test_error_transformation.rs
@@ -31,7 +31,7 @@ fn test_serde_json_error_transformation() {
 #[derive(Serialize, Deserialize, Validate, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SearchParams {
-    #[validate]
+    #[validate(nested)]
     page_params: PageParams,
     #[validate(url)]
     redirect_results: String,


### PR DESCRIPTION
I updated the [validator](https://docs.rs/validator/latest/validator/) crate to `0.18`. 

Should resolve https://github.com/rambler-digital-solutions/actix-web-validator/issues/51

---

Note: That this is a breaking change :sweat_smile: 

